### PR TITLE
Reduce the time complexity of the function

### DIFF
--- a/prime_numbers.py
+++ b/prime_numbers.py
@@ -1,17 +1,12 @@
+import math
+
 def all_prime_numbers_below_n(num):
 
+    #check divisors from 2 to sqrt(n) only instead of from 2 to n-1
     for num in range(2,num):
-
-        prime = True
-
-        for x in range(2,num):
-
-            if (num%x==0):
-                prime = False
-
-        if prime:
-            print(num,"is prime")
+        if all(num%i!=0 for i in range(2,int(math.sqrt(num))+1)):
+           print num
 
 
-n = int(input("Enter max number: "))
+n = int(input("Enter max range number: "))
 all_prime_numbers_below_n(n)


### PR DESCRIPTION
Reduce the time complexity of the function by checking for divisors from 2 to sqrt(n) only instead of from 2 to n-1. 

since n = a_b, If both a and b were greater than the square root of n, a_b would be greater than n. So at least one of those factors must be less than or equal to the square root of n, and to check if n is prime, we only need to test for factors less than or equal to the square root.
