### PR TITLE
Reduce time complexity further in the function

### DIFF
--- a/prime_numbers.py
+++ b/prime_numbers.py
@@ -2,11 +2,12 @@ import math
 
 def all_prime_numbers_below_n(num):
 
-    #check divisors from 2 to sqrt(n) only instead of from 2 to n-1
-    for num in range(2,num):
+    #The only even prime number
+    print 2
+    for num in range(3,num,2):
+        #increment range you by 2, and only check odd numbers
         if all(num%i!=0 for i in range(2,int(math.sqrt(num))+1)):
            print num
-
 
 n = int(input("Enter max range number: "))
 all_prime_numbers_below_n(n)


### PR DESCRIPTION
Since the only even prime number is 2, we can skip all other even numbers by incrementing the range by 2, and hence only checking for the odd numbers thereby reducing the time complexity further.
